### PR TITLE
Fix live preview Component lifecycle leak

### DIFF
--- a/src/live-preview.ts
+++ b/src/live-preview.ts
@@ -75,6 +75,7 @@ class KvlRowWidget extends WidgetType {
   private readonly renderKey: string;
   private readonly renderComponent = new Component();
   private readonly pendingRenders: Promise<unknown>[] = [];
+  private componentLoaded = false;
 
   constructor(
     private readonly plugin: KeyValueListPlugin,
@@ -109,7 +110,10 @@ class KvlRowWidget extends WidgetType {
   }
 
   toDOM(view: EditorView): HTMLElement {
-    this.renderComponent.load();
+    if (!this.componentLoaded) {
+      this.renderComponent.load();
+      this.componentLoaded = true;
+    }
     const doc = view?.dom?.ownerDocument ?? document;
     const pieces = splitKeyValueLine(
       this.lineText,
@@ -190,7 +194,10 @@ class KvlRowWidget extends WidgetType {
 
   destroy(): void {
     void Promise.all(this.pendingRenders).finally(() => {
-      this.renderComponent.unload();
+      if (this.componentLoaded) {
+        this.renderComponent.unload();
+        this.componentLoaded = false;
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- Guard `renderComponent.load()` in `KvlRowWidget.toDOM()` so it runs at most once per widget instance
- Only call `unload()` in `destroy()` when the component was actually loaded, keeping the lifecycle balanced

## Test plan
- [x] `npm test` (37 tests pass)
- [x] Open a note with key-value lists in live preview and edit lines to trigger decoration rebuilds
- [x] Switch between notes/files and confirm no stale renders or console errors

Made with [Cursor](https://cursor.com)